### PR TITLE
Allow setting any schema

### DIFF
--- a/src/Postgres.fs
+++ b/src/Postgres.fs
@@ -51,19 +51,28 @@ module Postgres =
     let private storeSettingsWithPooling (config: PostgresConfig) (pooling: PoolingConfig): string =
         sprintf "%s;%s" (storeSettings config) (poolingSettings pooling)
 
-    let createStore (config: PostgresConfig): SqlStreamStore.PostgresStreamStore =
-        let settings =
-            SqlStreamStore.PostgresStreamStoreSettings(storeSettings config)
-
+    let private setSettingsSchema (config: PostgresConfig)
+                                  (settings: SqlStreamStore.PostgresStreamStoreSettings)
+                                  : SqlStreamStore.PostgresStreamStoreSettings =
         match config.schema with
         | None -> ()
         | Some (schema) -> settings.Schema <- schema
 
+        settings
+
+    let createStore (config: PostgresConfig): SqlStreamStore.PostgresStreamStore =
+        let settings =
+            SqlStreamStore.PostgresStreamStoreSettings(storeSettings config)
+            |> setSettingsSchema config
+
         new SqlStreamStore.PostgresStreamStore(settings)
 
     let createStoreWithPoolingConfig (config: PostgresConfig) (pooling: PoolingConfig): SqlStreamStore.PostgresStreamStore =
-        new SqlStreamStore.PostgresStreamStore(SqlStreamStore.PostgresStreamStoreSettings
-                                                   (storeSettingsWithPooling config pooling))
+        let settings =
+            SqlStreamStore.PostgresStreamStoreSettings(storeSettingsWithPooling config pooling)
+            |> setSettingsSchema config
+
+        new SqlStreamStore.PostgresStreamStore(settings)
 
     let createStoreWithConfigString (config: string): SqlStreamStore.PostgresStreamStore =
         new SqlStreamStore.PostgresStreamStore(SqlStreamStore.PostgresStreamStoreSettings(config))

--- a/src/Postgres.fs
+++ b/src/Postgres.fs
@@ -7,7 +7,8 @@ type PostgresConfig =
       port: string
       username: string
       password: string
-      database: string }
+      database: string
+      schema: string option }
 
 type PoolingConfig =
     { minPoolSize: int option
@@ -51,7 +52,14 @@ module Postgres =
         sprintf "%s;%s" (storeSettings config) (poolingSettings pooling)
 
     let createStore (config: PostgresConfig): SqlStreamStore.PostgresStreamStore =
-        new SqlStreamStore.PostgresStreamStore(SqlStreamStore.PostgresStreamStoreSettings(storeSettings config))
+        let settings =
+            SqlStreamStore.PostgresStreamStoreSettings(storeSettings config)
+
+        match config.schema with
+        | None -> ()
+        | Some (schema) -> settings.Schema <- schema
+
+        new SqlStreamStore.PostgresStreamStore(settings)
 
     let createStoreWithPoolingConfig (config: PostgresConfig) (pooling: PoolingConfig): SqlStreamStore.PostgresStreamStore =
         new SqlStreamStore.PostgresStreamStore(SqlStreamStore.PostgresStreamStoreSettings


### PR DESCRIPTION
### Problem
The wrappers don't allow specifying the schema. 

### Solution
Add a new optional schema field to the PostgresConfig record

We tested this locally.