### PR TITLE
Add `GetAll` module

### DIFF
--- a/src/Get.fs
+++ b/src/Get.fs
@@ -5,6 +5,7 @@ open SqlStreamStore.Streams
 
 module Get =
 
+    // A function to help wit type inference in this module
     let private curriedMap : (ReadStreamPage -> 'a) -> AsyncResult<ReadStreamPage, exn> -> AsyncResult<'a, exn> =
         AsyncResult.map
 
@@ -36,6 +37,33 @@ module Get =
 
     let nextStreamVersion =
         curriedMap (fun page -> page.NextStreamVersion)
+
+module GetAll =
+
+    // A function to help wit type inference in this module
+    let private curriedMap : (ReadAllPage -> 'a) -> AsyncResult<ReadAllPage, exn> -> AsyncResult<'a, exn> =
+        AsyncResult.map
+
+    let messages =
+        curriedMap (fun page -> page.Messages |> Array.toList)
+
+    let messagesData =
+        messages
+        >> AsyncResult.bind (List.traverseAsyncResultM (fun msg -> msg.GetJsonData()))
+
+    let messagesDataAs<'data> =
+        messages
+        >> AsyncResult.bind (List.traverseAsyncResultM (fun msg -> msg.GetJsonDataAs<'data>()))
+
+    let direction = curriedMap (fun page -> page.Direction)
+
+    let fromPosition =
+        curriedMap (fun page -> page.FromPosition)
+
+    let isEnd = curriedMap (fun page -> page.IsEnd)
+
+    let nextPosition =
+        curriedMap (fun page -> page.NextPosition)
 
 
 namespace SqlStreamStore.FSharp.EventSourcing

--- a/src/Get.fs
+++ b/src/Get.fs
@@ -38,6 +38,9 @@ module Get =
     let nextStreamVersion =
         curriedMap (fun page -> page.NextStreamVersion)
 
+    let nextStreamPage =
+        AsyncResult.bind (fun (page: ReadStreamPage) -> page.ReadNext |> AsyncResult.ofTask)
+
 module GetAll =
 
     // A function to help wit type inference in this module
@@ -64,6 +67,9 @@ module GetAll =
 
     let nextPosition =
         curriedMap (fun page -> page.NextPosition)
+
+    let nextAllStreamPage =
+        AsyncResult.bind (fun (page: ReadAllPage) -> page.ReadNext |> AsyncResult.ofTask)
 
 
 namespace SqlStreamStore.FSharp.EventSourcing

--- a/src/SqlStreamStore.FSharp.fsproj
+++ b/src/SqlStreamStore.FSharp.fsproj
@@ -10,26 +10,26 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>SqlStreamStore; FSharp; postgresql; cqrs; event-sourcing; event-store; stream-store</PackageTags>
     </PropertyGroup>
-    
+
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="5.0.0" />
-        <PackageReference Include="FSharp.Prelude" Version="3.0.0" />
-        <PackageReference Include="FSharp.SystemTextJson" Version="0.16.6" />
-        <PackageReference Include="Npgsql" Version="5.0.4" />
-        <PackageReference Include="SqlStreamStore" Version="1.2.0-beta.8" />
-        <PackageReference Include="SqlStreamStore.Postgres" Version="1.2.0-beta.8" />
+        <PackageReference Update="FSharp.Core" Version="5.0.0"/>
+        <PackageReference Include="FSharp.Prelude" Version="3.0.0"/>
+        <PackageReference Include="FSharp.SystemTextJson" Version="0.16.6"/>
+        <PackageReference Include="Npgsql" Version="5.0.4"/>
+        <PackageReference Include="SqlStreamStore" Version="1.2.0-beta.8"/>
+        <PackageReference Include="SqlStreamStore.Postgres" Version="1.2.0-beta.8"/>
     </ItemGroup>
-    
+
     <ItemGroup>
-      <Compile Include="Infrastructure.fs" />
-      <Compile Include="SqlStreamStoreExtensions.fs" />
-      <Compile Include="StreamEvent.fs" />
-      <Compile Include="Create.fs" />
-      <Compile Include="Connect.fs" />
-      <Compile Include="Append.fs" />
-      <Compile Include="Read.fs" />
-      <Compile Include="Get.fs" />
-      <Compile Include="Subscribe.fs" />
+        <Compile Include="Infrastructure.fs"/>
+        <Compile Include="SqlStreamStoreExtensions.fs"/>
+        <Compile Include="StreamEvent.fs"/>
+        <Compile Include="Create.fs"/>
+        <Compile Include="Connect.fs"/>
+        <Compile Include="Append.fs"/>
+        <Compile Include="Read.fs"/>
+        <Compile Include="Get.fs"/>
+        <Compile Include="Subscribe.fs"/>
     </ItemGroup>
-    
+
 </Project>

--- a/src/SqlStreamStoreExtensions.fs
+++ b/src/SqlStreamStoreExtensions.fs
@@ -17,7 +17,7 @@ module SqlStreamExtensions =
     let private getJsonDataAs<'a> (streamMessage: StreamMessage) =
         asyncResult {
             let! json = getJsonData streamMessage
-            return JayJson.decode<'a> json
+            return! JayJson.decode<'a> json
         }
 
     type StreamMessage with

--- a/src/SqlStreamStoreExtensions.fs
+++ b/src/SqlStreamStoreExtensions.fs
@@ -264,7 +264,6 @@ module SqlStreamExtensions =
 
             readStreamForwards this streamId fromVersionInclusive' maxCount' prefetch' cancellationToken'
 
-
         /// Lists Streams in SQLStreamStore.
         /// Defaults: maxCount = 1000, continuationToken = null
         member this.ListStreams(?maxCount: int, ?continuationToken: string) =


### PR DESCRIPTION
- Add `GetAll` module to get some data from a `ReadAllStreamPage`
- Fix a minor bug when using `StreamMessage.GetMessageAs<'a>` extension
- Add `nextStreamPage` function to the `Get` module